### PR TITLE
AMD compatibility: guard nunchaku imports

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -13,11 +13,33 @@ __version__ = "1.38"
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)
 
-# Import nodes
-from .nodes.lora.flux import NunchakuFluxLoraStack
-from .nodes.lora.flux_v2 import GENERATED_NODES as FLUX_NODES, GENERATED_DISPLAY_NAMES as FLUX_NAMES
-from .nodes.lora.standard import GENERATED_NODES as STANDARD_LORA_NODES, GENERATED_DISPLAY_NAMES as STANDARD_LORA_NAMES
-from .nodes.lora.standard_v3 import GENERATED_NODES as STANDARD_LORA_V3_NODES, GENERATED_DISPLAY_NAMES as STANDARD_LORA_V3_NAMES
+# Import nodes - nunchaku-dependent imports are guarded for AMD/non-NVIDIA systems
+try:
+    from .nodes.lora.flux import NunchakuFluxLoraStack
+    from .nodes.lora.flux_v2 import GENERATED_NODES as FLUX_NODES, GENERATED_DISPLAY_NAMES as FLUX_NAMES
+    _FLUX_AVAILABLE = True
+except Exception as e:
+    logger.warning(f"[ROCm] Skipping nunchaku FLUX nodes: {e}")
+    NunchakuFluxLoraStack = None
+    FLUX_NODES = {}
+    FLUX_NAMES = {}
+    _FLUX_AVAILABLE = False
+
+try:
+    from .nodes.lora.standard import GENERATED_NODES as STANDARD_LORA_NODES, GENERATED_DISPLAY_NAMES as STANDARD_LORA_NAMES
+except Exception as e:
+    logger.warning(f"[ROCm] Skipping standard LoRA nodes: {e}")
+    STANDARD_LORA_NODES = {}
+    STANDARD_LORA_NAMES = {}
+
+try:
+    from .nodes.lora.standard_v3 import GENERATED_NODES as STANDARD_LORA_V3_NODES, GENERATED_DISPLAY_NAMES as STANDARD_LORA_V3_NAMES
+except Exception as e:
+    logger.warning(f"[ROCm] Skipping standard LoRA v3 nodes: {e}")
+    STANDARD_LORA_V3_NODES = {}
+    STANDARD_LORA_V3_NAMES = {}
+
+
 from .nodes.lora.sdnq import GENERATED_NODES as SDNQ_LORA_NODES, GENERATED_DISPLAY_NAMES as SDNQ_LORA_NAMES
 from .nodes.misc_v2 import NODE_CLASS_MAPPINGS as MISC_NODES, NODE_DISPLAY_NAME_MAPPINGS as MISC_NAMES
 from .nodes.load_image_ussoewwin import NODE_CLASS_MAPPINGS as LOAD_IMAGE_NODES, NODE_DISPLAY_NAME_MAPPINGS as LOAD_IMAGE_NAMES
@@ -29,7 +51,8 @@ from .nodes.CCSR import NODE_CLASS_MAPPINGS as CCSR_NODES, NODE_DISPLAY_NAME_MAP
 from .nodes.resolution_selector import NODE_CLASS_MAPPINGS as RESOLUTION_SELECTOR_NODES, NODE_DISPLAY_NAME_MAPPINGS as RESOLUTION_SELECTOR_NAMES
 
 # Add version to classes
-NunchakuFluxLoraStack.__version__ = __version__
+if NunchakuFluxLoraStack is not None:
+    NunchakuFluxLoraStack.__version__ = __version__
 for node_class in FLUX_NODES.values():
     node_class.__version__ = __version__
 for node_class in STANDARD_LORA_NODES.values():
@@ -45,7 +68,7 @@ for node_class in CCSR_NODES.values():
 
 # Node mappings
 NODE_CLASS_MAPPINGS = {
-    "FluxLoraMultiLoader": NunchakuFluxLoraStack,
+    **({} if NunchakuFluxLoraStack is None else {"FluxLoraMultiLoader": NunchakuFluxLoraStack}),
     **FLUX_NODES,
     **STANDARD_LORA_NODES,
     **STANDARD_LORA_V3_NODES,
@@ -62,7 +85,7 @@ NODE_CLASS_MAPPINGS = {
 
 # Display name mappings
 NODE_DISPLAY_NAME_MAPPINGS = {
-    "FluxLoraMultiLoader": "FLUX LoRA Multi Loader (Legacy - Do Not Use in V2)",
+    **({} if NunchakuFluxLoraStack is None else {"FluxLoraMultiLoader": "FLUX LoRA Multi Loader (Legacy - Do Not Use in V2)"}),
     **FLUX_NAMES,
     **STANDARD_LORA_NAMES,
     **STANDARD_LORA_V3_NAMES,

--- a/nodes/lora/flux.py
+++ b/nodes/lora/flux.py
@@ -270,7 +270,10 @@ class NunchakuFluxLoraStack:
             print("DEBUG: Using NunchakuFluxTransformer2dModel LoRA application method")
 
             if loras_formatted:
-                from nunchaku.lora.flux.compose import compose_lora as nunchaku_compose_lora
+                try:
+                    from nunchaku.lora.flux.compose import compose_lora as nunchaku_compose_lora
+                except ImportError:
+                    nunchaku_compose_lora = None
 
                 lora_tuples = []
                 for lora_name, lora_strength in loras_formatted:

--- a/nodes/lora/flux_v2.py
+++ b/nodes/lora/flux_v2.py
@@ -119,7 +119,10 @@ class FluxLoraMultiLoaderBase:
                 ret_wrapper.loras.append((path, strength))
         elif wrapper_class == "NunchakuFluxTransformer2dModel":
             if loras_formatted:
-                from nunchaku.lora.flux.compose import compose_lora
+                try:
+                    from nunchaku.lora.flux.compose import compose_lora
+                except ImportError:
+                    compose_lora = None
                 tuples = [(folder_paths.get_full_path_or_raise("loras", n), s) for n, s in loras_formatted]
                 if len(tuples) == 1:
                     ret_wrapper.update_lora_params(tuples[0][0])

--- a/nodes/lora/sdnq.py
+++ b/nodes/lora/sdnq.py
@@ -152,7 +152,9 @@ class StandardLoraLoaderBase:
                     print(f"[SDNQ LoRA Stacker] ✓ LoRA {i} loaded: {lora_selection} (strength: {lora_strength})")
                     
                 except Exception as e:
+                    import traceback
                     print(f"[SDNQ LoRA Stacker] ⚠️  Failed to load LoRA {i} ({lora_selection}): {e}")
+                    traceback.print_exc()
                     continue
         
         # Set all adapters with their weights

--- a/wrappers/flux.py
+++ b/wrappers/flux.py
@@ -12,10 +12,19 @@ from comfy.ldm.common_dit import pad_to_patch_size
 from einops import rearrange, repeat
 from torch import nn
 
-from nunchaku import NunchakuFluxTransformer2dModel
-from nunchaku.caching.fbcache import cache_context, create_cache_context
-from nunchaku.lora.flux.compose import compose_lora
-from nunchaku.utils import load_state_dict_in_safetensors
+try:
+    from nunchaku import NunchakuFluxTransformer2dModel
+    from nunchaku.caching.fbcache import cache_context, create_cache_context
+    from nunchaku.lora.flux.compose import compose_lora
+    from nunchaku.utils import load_state_dict_in_safetensors
+    _NUNCHAKU_AVAILABLE = True
+except ImportError:
+    NunchakuFluxTransformer2dModel = None
+    cache_context = None
+    create_cache_context = None
+    compose_lora = None
+    load_state_dict_in_safetensors = None
+    _NUNCHAKU_AVAILABLE = False
 
 
 class ComfyFluxWrapper(nn.Module):


### PR DESCRIPTION
`nunchaku` ships CUDA-only kernels, so on ROCm its import fails - and because it's imported at module scope, that takes down the entire node pack rather than just the FLUX nodes.

- `wrappers/flux.py` - guard the top-level `nunchaku` imports
- `nodes/lora/flux.py`, `flux_v2.py` - guard the local `compose_lora` imports
- `__init__.py` - skip the nunchaku-dependent node groups, register the rest
- `nodes/lora/sdnq.py` - print a traceback on LoRA load failure

No change in behaviour when nunchaku is installed. Tested on Windows + torch 2.12.0+rocm7.15.